### PR TITLE
Fix CR/NL error for python on windows

### DIFF
--- a/bin/git-credential-keepasshttp
+++ b/bin/git-credential-keepasshttp
@@ -38,8 +38,8 @@ if operation == "get":
     except AttributeError:
         repo_logins = session.getLogins('%s://%s/' % (repo_info['protocol'], repo_info['host']))
     if repo_logins:
-        print("username=%s" % repo_logins[0]['Login'])
-        print("password=%s" % repo_logins[0]['Password'].value)
+        sys.stdout.buffer.write(bytes("username=%s\n" % repo_logins[0]['Login'],'UTF-8'))
+        sys.stdout.buffer.write(bytes("password=%s\n" % repo_logins[0]['Password'].value,'UTF-8'))
     else:
         sys.stderr.write("Couldn't find credentials for host\n")
         sys.exit(1)


### PR DESCRIPTION
On Windows, python replaces newline with carriage-return + newline. Therefore the git credentials don't work, as they appear as "username\r".

They only solution i found is to output a string converted to bytes in binary mode.